### PR TITLE
Return 0 if no staged files to check

### DIFF
--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -2,13 +2,15 @@
 exec rspec spec
 
 #Check for pry leftovers, No desert if you have leftovers
-FILES_PATTERN='\.(rb)(\..+)?$'
+FILES_PATTERN='\.(e?rb)(\..+)?$'
 FORBIDDEN='binding.pry'
 
-git diff --cached --name-only | \
-    grep -E $FILES_PATTERN | \
-    GREP_COLOR='4;5;37;41' xargs grep --color --with-filename -n $FORBIDDEN && \
-    echo 'COMMIT REJECTED' && \
-    exit 1
+if [[ $(git diff --cached --name-only | grep -E $FILES_PATTERN) ]]; then
+  git diff --cached --name-only | \
+      grep -E $FILES_PATTERN | \
+      GREP_COLOR='4;5;37;41' xargs grep --color --with-filename -n $FORBIDDEN && \
+      echo 'COMMIT REJECTED' && \
+      exit 1
+fi
 
 exit 0


### PR DESCRIPTION
OSX will always return 1 when there are no .rb files staged for commit. This is because the xargs in the pipeline will always return true when passed an empty string. This fix will check for staged .rb and .erb files and only return 1 if a binding.pry is found.