### PR TITLE
Fix PostToolUse hook firing PR reminder after every Bash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ mkdir -p ~/.claude
 ln -sf ~/dot_files/claude-global.md ~/.claude/CLAUDE.md
 ```
 
+### Claude Code Global Settings
+
+Symlink the global `settings.json` (permissions, hooks, plugins, defaults) so it's
+version-tracked in this repo. Machine-local overrides go in `~/.claude/settings.local.json`,
+which is intentionally left untracked.
+
+```bash
+mkdir -p ~/.claude
+ln -sf ~/dot_files/claude-settings.json ~/.claude/settings.json
+```
+
 ### Better search with Ag
 
 macOS:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Symlink hook scripts so Claude Code's global settings can reference them:
 mkdir -p ~/.claude/hooks
 ln -sf ~/dot_files/sync-tab-color.sh ~/.claude/hooks/sync-tab-color.sh
 ln -sf ~/dot_files/spending-tracker.sh ~/.claude/hooks/spending-tracker.sh
+ln -sf ~/dot_files/pr-created-reminder.sh ~/.claude/hooks/pr-created-reminder.sh
 ```
 
 `notify.sh` is referenced directly from the repo (`$HOME/dot_files/notify.sh`) so no symlink is needed.
@@ -146,7 +147,7 @@ git config credential.helper store
 ## Tools
 
 - **`commit-velocity`** — Ruby CLI for per-author commit analytics with moving averages, quarterly rollups, and trend arrows. Run `commit-velocity --help` for options.
-- **`sync-tab-color.sh` / `spending-tracker.sh` / `notify.sh`** — Claude Code hooks (see above) for iTerm tab coloring per session, token-spend alerts, and terminal notifications.
+- **`sync-tab-color.sh` / `spending-tracker.sh` / `notify.sh` / `pr-created-reminder.sh`** — Claude Code hooks (see above) for iTerm tab coloring per session, token-spend alerts, terminal notifications, and reminding to run `/review` before enabling auto-merge after a `gh pr create`.
 - **`workflow-remover.sh`** — deletes runs of disabled GitHub Actions workflows. Usage: `workflow-remover.sh <org> <repo>`.
 
 ## Keyboard

--- a/claude-settings.json
+++ b/claude-settings.json
@@ -1,0 +1,103 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(npm:*)",
+      "Bash(npx:*)",
+      "Bash(node:*)",
+      "Bash(ls:*)",
+      "Bash(cp:*)",
+      "Bash(mv:*)",
+      "Bash(mkdir:*)",
+      "Bash(rm:*)",
+      "Bash(chmod:*)",
+      "Bash(unzip:*)",
+      "Bash(sips:*)",
+      "Bash(python3:*)",
+      "Bash(pip3 install:*)",
+      "Bash(ruby:*)",
+      "Bash(vite:*)",
+      "Bash(wrangler:*)",
+      "Bash(wxt:*)",
+      "Bash(yt-dlp:*)",
+      "Bash(bundle:*)",
+      "Bash(gem:*)",
+      "Bash(rbenv:*)",
+      "Bash(rails:*)",
+      "Bash(./manage.sh:*)",
+      "Bash(./start.sh:*)",
+      "Bash(docker:*)",
+      "Bash(fly:*)",
+      "WebSearch",
+      "WebFetch(domain:localhost)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:fly.io)",
+      "WebFetch(domain:deepwiki.com)",
+      "WebFetch(domain:chromewebstore.google.com)"
+    ],
+    "defaultMode": "auto"
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/pr-created-reminder.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/dot_files/notify.sh"
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/spending-tracker.sh",
+            "timeout": 30,
+            "statusMessage": "Tracking spend…",
+            "async": true
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/sync-tab-color.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/dot_files/notify.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true,
+    "ruby-lsp@claude-plugins-official": true,
+    "cloudflare@claude-plugins-official": true
+  },
+  "effortLevel": "xhigh",
+  "tui": "fullscreen",
+  "skipDangerousModePermissionPrompt": true,
+  "skipWorkflowUsageWarning": true,
+  "editorMode": "vim",
+  "autoCompactEnabled": true,
+  "remoteControlAtStartup": true,
+  "agentPushNotifEnabled": true,
+  "skipAutoPermissionPrompt": true
+}

--- a/pr-created-reminder.sh
+++ b/pr-created-reminder.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# PostToolUse (Bash) hook.
+#
+# Remind to run /review before enabling auto-merge — but ONLY after `gh pr create`.
+# A hook's `matcher` can only filter by tool name (e.g. "Bash"), not by the command
+# text, so this script inspects the actual command and stays silent unless a PR was
+# really created. (The old inline hook used a bogus `"if"` key that Claude Code ignores,
+# so it fired the reminder after every Bash command — a constant false trigger.)
+cmd="$(cat | jq -r '.tool_input.command // ""' 2>/dev/null)"
+# Match only at a command boundary (line start, or after && || ; | ( ) so that
+# commit messages / echoes that merely mention the phrase don't trigger it.
+if printf '%s' "$cmd" | grep -Eq '(^|[|&;(]|&&|\|\|)[[:space:]]*gh[[:space:]]+pr[[:space:]]+create'; then
+  printf '%s' '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"A PR was just created. Before enabling auto-merge: run /review on the PR diff, address the findings, and ONLY THEN enable auto-merge (gh pr merge --auto --squash)."}}'
+fi
+exit 0

--- a/pr-created-reminder.sh
+++ b/pr-created-reminder.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 # PostToolUse (Bash) hook.
 #
-# Remind to run /review before enabling auto-merge — but ONLY after `gh pr create`.
-# A hook's `matcher` can only filter by tool name (e.g. "Bash"), not by the command
-# text, so this script inspects the actual command and stays silent unless a PR was
-# really created. (The old inline hook used a bogus `"if"` key that Claude Code ignores,
-# so it fired the reminder after every Bash command — a constant false trigger.)
-cmd="$(cat | jq -r '.tool_input.command // ""' 2>/dev/null)"
-# Match only at a command boundary (line start, or after && || ; | ( ) so that
-# commit messages / echoes that merely mention the phrase don't trigger it.
-if printf '%s' "$cmd" | grep -Eq '(^|[|&;(]|&&|\|\|)[[:space:]]*gh[[:space:]]+pr[[:space:]]+create'; then
+# Remind to run /review before enabling auto-merge — but ONLY after a `gh pr create`
+# that actually created a PR.
+#
+# A hook's `matcher` filters by tool name only (e.g. "Bash"), not command text, so
+# the check has to live here. Matching the command string alone is unreliable: the
+# phrase "gh pr create" also shows up in commit messages, `echo`, `--help`, and
+# failed/aborted runs. So we require TWO signals from the PostToolUse payload:
+#   1. the command referenced `gh pr create`, and
+#   2. the tool output contains a freshly created PR URL (.../pull/<n>).
+# `gh pr create` prints that URL to stdout on success, so together these fire the
+# reminder exactly when a PR was really created. Requires jq (as do the sibling hooks).
+input="$(cat)"
+cmd="$(jq -r '.tool_input.command // ""' <<<"$input" 2>/dev/null)"
+resp="$(jq -r '.tool_response // "" | tostring' <<<"$input" 2>/dev/null)"
+
+if printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]_])gh[[:space:]]+pr[[:space:]]+create' \
+   && printf '%s' "$resp" | grep -Eq 'https://github\.com/[^/[:space:]]+/[^/[:space:]]+/pull/[0-9]+'; then
   printf '%s' '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"A PR was just created. Before enabling auto-merge: run /review on the PR diff, address the findings, and ONLY THEN enable auto-merge (gh pr merge --auto --squash)."}}'
 fi
 exit 0

--- a/pr-created-reminder.sh
+++ b/pr-created-reminder.sh
@@ -9,15 +9,21 @@
 # phrase "gh pr create" also shows up in commit messages, `echo`, `--help`, and
 # failed/aborted runs. So we require TWO signals from the PostToolUse payload:
 #   1. the command referenced `gh pr create`, and
-#   2. the tool output contains a freshly created PR URL (.../pull/<n>).
-# `gh pr create` prints that URL to stdout on success, so together these fire the
-# reminder exactly when a PR was really created. Requires jq (as do the sibling hooks).
+#   2. its STDOUT contains a created PR URL (.../pull/<n>).
+# `gh pr create` prints that URL to stdout on success. We deliberately ignore stderr:
+# a failed run (e.g. "a pull request ... already exists: <url>") writes its URL there,
+# and we don't want to claim a PR was "just created" when none was. Requires jq (as do
+# the sibling hooks).
 input="$(cat)"
-cmd="$(jq -r '.tool_input.command // ""' <<<"$input" 2>/dev/null)"
-resp="$(jq -r '.tool_response // "" | tostring' <<<"$input" 2>/dev/null)"
 
-if printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]_])gh[[:space:]]+pr[[:space:]]+create' \
-   && printf '%s' "$resp" | grep -Eq 'https://github\.com/[^/[:space:]]+/[^/[:space:]]+/pull/[0-9]+'; then
+# Cheap check first — bail before touching the (possibly huge) response payload on the
+# hot path, since this hook runs after every Bash command.
+cmd="$(jq -r '.tool_input.command // ""' <<<"$input" 2>/dev/null)"
+printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]_])gh[[:space:]]+pr[[:space:]]+create' || exit 0
+
+# Confirm a PR was really created: look for a fresh PR URL in stdout only.
+out="$(jq -r '(.tool_response // "") | if type == "object" then (.stdout // "") else tostring end' <<<"$input" 2>/dev/null)"
+if printf '%s' "$out" | grep -Eq 'https://github\.com/[^/[:space:]]+/[^/[:space:]]+/pull/[0-9]+'; then
   printf '%s' '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"A PR was just created. Before enabling auto-merge: run /review on the PR diff, address the findings, and ONLY THEN enable auto-merge (gh pr merge --auto --squash)."}}'
 fi
 exit 0


### PR DESCRIPTION
Fixes a global Claude Code hook that injected an "A PR was just created" reminder after **every** Bash command. The old inline hook used a bogus `"if": "Bash(gh pr create:*)"` key (Claude Code ignores unknown keys) with `matcher: "Bash"`, so it fired on every shell command — a constant false trigger.

**Changes:**
- `pr-created-reminder.sh` — new PostToolUse hook (symlinked into `~/.claude/hooks/` like the sibling hooks). Fires the reminder only when two signals agree: the command referenced `gh pr create` **and** the tool output contains a freshly created PR URL. This avoids false positives (commit messages, echoes, `--help`, failed runs) and false negatives (env-prefixed/wrapped invocations).
- `claude-settings.json` — the global `~/.claude/settings.json` is now tracked in the repo and symlinked into place (matching `claude-global.md`), so its config is backed up. Machine-local overrides stay in the untracked `settings.local.json`.
- `README.md` — document both symlinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
